### PR TITLE
Added support for Indicate

### DIFF
--- a/BLEServer/BLEServer/BLEServer.cpp
+++ b/BLEServer/BLEServer/BLEServer.cpp
@@ -278,10 +278,24 @@ unsigned long nextSubscriptionId = 1;
 concurrency::task<IJsonValue^> subscribeRequest(JsonObject ^command) {
 	auto characteristic = co_await getCharacteristic(command);
 
-	auto status = co_await characteristic->WriteClientCharacteristicConfigurationDescriptorAsync(Bluetooth::GenericAttributeProfile::GattClientCharacteristicConfigurationDescriptorValue::Notify);
-	if (status != Bluetooth::GenericAttributeProfile::GattCommunicationStatus::Success)
-	{
-		throw ref new FailureException(status.ToString());
+	auto props = (unsigned int)characteristic->CharacteristicProperties;
+
+	if (props & (unsigned int)Bluetooth::GenericAttributeProfile::GattCharacteristicProperties::Notify) {
+		auto status = co_await characteristic->WriteClientCharacteristicConfigurationDescriptorAsync(Bluetooth::GenericAttributeProfile::GattClientCharacteristicConfigurationDescriptorValue::Notify);
+		if (status != Bluetooth::GenericAttributeProfile::GattCommunicationStatus::Success)
+		{
+			throw ref new FailureException(status.ToString());
+		}
+	}
+	else if (props & (unsigned int)Bluetooth::GenericAttributeProfile::GattCharacteristicProperties::Indicate) {
+		auto status = co_await characteristic->WriteClientCharacteristicConfigurationDescriptorAsync(Bluetooth::GenericAttributeProfile::GattClientCharacteristicConfigurationDescriptorValue::Indicate);
+		if (status != Bluetooth::GenericAttributeProfile::GattCommunicationStatus::Success)
+		{
+			throw ref new FailureException(status.ToString());
+		}
+	}
+	else {
+			throw ref new FailureException("Operation not supported.");
 	}
 
 	auto key = characteristicKey(command);

--- a/BLEServer/BLEServer/BLEServer.cpp
+++ b/BLEServer/BLEServer/BLEServer.cpp
@@ -295,7 +295,7 @@ concurrency::task<IJsonValue^> subscribeRequest(JsonObject ^command) {
 		}
 	}
 	else {
-			throw ref new FailureException("Operation not supported.");
+		throw ref new FailureException("Operation not supported.");
 	}
 
 	auto key = characteristicKey(command);


### PR DESCRIPTION
I have a 2 similar Bluetooth devices that are both using the same custom characteristic.  On one device that characteristic supports Notify and Indicate.  On the other device it only supports Indicate.  Noble-winrt worked great for the first device and did not work with the second device.  After I made these changes to bleserver.cpp, compiled it, and replaced the pre-compiled bleserver.exe binary, it now works with both devices.