### PR TITLE
VIVI-5229 Retrieve Raw AD strcutures

### DIFF
--- a/BLEServer/BLEServer.sln
+++ b/BLEServer/BLEServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BLEServer", "BLEServer\BLEServer.vcxproj", "{D415077E-CC9E-4C6B-919B-80F4F467307E}"
 EndProject
@@ -13,8 +13,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Debug|x64.ActiveCfg = Debug|x64
-		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Debug|x64.Build.0 = Debug|x64
+		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Debug|x64.ActiveCfg = Release|x64
+		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Debug|x64.Build.0 = Release|x64
 		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Debug|x86.ActiveCfg = Debug|Win32
 		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Debug|x86.Build.0 = Debug|Win32
 		{D415077E-CC9E-4C6B-919B-80F4F467307E}.Release|x64.ActiveCfg = Release|x64
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A5C3FD2B-ED67-4115-9B58-90CC11F8A6AF}
 	EndGlobalSection
 EndGlobal

--- a/BLEServer/BLEServer/BLEServer.vcxproj
+++ b/BLEServer/BLEServer/BLEServer.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{D415077E-CC9E-4C6B-919B-80F4F467307E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>BLEServer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -107,7 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <CompileAsWinRT>true</CompileAsWinRT>
       <MinimalRebuild>false</MinimalRebuild>
-      <AdditionalUsingDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\vcpackages;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\vcpackages;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -145,7 +145,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <CompileAsWinRT>true</CompileAsWinRT>
-      <AdditionalUsingDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\vcpackages;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\vcpackages;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# VIVI SPECIFIC NOTES
+
+The `BLEServer` executable is required for the proper operation fo `noble-winrt`. Hopefully, this becomes obsolete with the implementation of the Chrome web bluetooth API, but for now, the web bluetooth API does not allow for a BLE scan of multiple devices. That means that we can only see the information for one box at a time.
+
+When a device advertises with BLE, the payload contains a number of "AD structures". AD structures contain data such as the name of a device, the signal strength, and manufacturer data. In the unmodified version of `web-bluetooth-polyfill`, only a select few AD structures are read, including the name, transmission power, and service UUIDs. This means that it does not read our "service data" AD structure that contains the beacon information.
+
+This mirror of `web-bluetooth-polyfill` contains a patch that dumps the raw data of all the AD structures when it discovers a bluetooth peripheral. This allows us to parse this data in javascript to retrieve the relevant information.
+
+To use this repository, build the `BLEserver` executable (`BLEServer.vcxproj`) using visual studio or `msbuild` and copy the executable into the `prebuilt` folder of the vivi `noble-winrt` repository.
+
+If you have any trouble with visual studio not being able to find `platform.winrt`, then make sure that the `Additional #using directories` is correct. The setting can be found in the `BLEServer` project under `C/C++` general settings.
+
 # Windows 10 Web Bluetooth Polyfill
 
 The Polyfill enables Web Bluetooth in Chrome on Windows 10. 


### PR DESCRIPTION
- Retrieve raw AD structures and serialize the data as part of the 'scanResult' response.
- In total, all the AD structures combined will amount to the complete advertisement

Ideally this whole repository becomes obsolete with the Web Bluetooth API, but for now, we need a better scanning API than what the current implementation provides.